### PR TITLE
Migrate all scripts to v2 context and web request pattern

### DIFF
--- a/Adobe-Cloud-Subscriptions.ps1
+++ b/Adobe-Cloud-Subscriptions.ps1
@@ -37,18 +37,16 @@ param (
     [string]$parameter = ""
 )
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
+. (Join-Path -Path $PSScriptRoot -ChildPath "include\WebRequest.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'Adobe'
 #end of default header ----------------------------------------------------------------------
-$filePath = "$($scope.DataDir)\adobe-$($scope.TimeStamp).inv"
+$filePath = "$($ctx.DataDir)\adobe-$($ctx.TimeStamp).inv"
 
-$organizationId = $scope.Parameters["organizationId"]
-$clientId = $scope.Parameters["clientId"]
-$clientSecret = $scope.Parameters["clientSecret"]
-$tenantName = $scope.Parameters["tenantName"]
-
-$env:DEBUG = "false"
-$DebugMode = [System.Convert]::ToBoolean($env:DEBUG)
+$organizationId = $ctx.UserParameters["organizationId"]
+$clientId = $ctx.UserParameters["clientId"]
+$clientSecret = $ctx.UserParameters["clientSecret"]
+$tenantName = $ctx.UserParameters["tenantName"]
 
 $loginUri = "https://ims-na1.adobelogin.com/ims/token/v3"
 $userManagementUri = "https://usermanagement.adobe.io/v2"
@@ -84,37 +82,22 @@ function Get-Access-Token {
     )
     Notify -name "Getting Access Token" -itemName "Getting Access Token" -itemResult "None" -message "Getting Access Token from $Uri" -category "Info" -state "None"
 
-    try {
-        $body = ConvertTo-UrlEncoded -Hashtable $FormData
-        $response = Invoke-RestMethod -Uri $Uri -Method Post -Body $body -Headers $Headers -ErrorAction Stop
-        Notify -name "Response Received" -itemName "Response Received" -itemResult "None" -message "Access Token Granted" -category "Info" -state "Finished"
-        return $response
-    }
-    catch {
-        Write-Error "Failed to get access token: $($_.Exception.Message)"
-        Write-Host "Status Code: $($_.Exception.Response.StatusCode)"
-        Write-Host "Response: $($_.Exception.Response.Content.ReadAsStringAsync().Result)"
+    $body = ConvertTo-UrlEncoded -Hashtable $FormData
+    $resp = Invoke-LoginWebRequest -Uri $Uri -Method POST -Body $body -Headers $Headers -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if (-not $resp.IsSuccess) {
+        Write-Error "Failed to get access token: HTTP $($resp.StatusCode) $($resp.StatusDescription)"
         return $null
     }
+
+    Notify -name "Response Received" -itemName "Response Received" -itemResult "None" -message "Access Token Granted" -category "Info" -state "Finished"
+    return ($resp.Body | ConvertFrom-Json)
 }
 
 try {
+    $token = Get-Access-Token -Uri $loginUri -FormData $formData -Headers $headers
 
-    if ($DebugMode) {
-        Write-Host "Reading token from file"
-        $token = Get-Content -Raw -Path ".\data\token.json" | ConvertFrom-Json
-        Write-Host "Access Token: $($token.access_token)"
-        Write-Host "Expires In: $($token.expires_in)"
-        Write-Host "Token Type: $($token.token_type)"
-    }
-    else {
-        $token = Get-Access-Token -Uri $loginUri -FormData $formData -Headers $headers
-    }
-
-    if ($token) {
-        #some debug output possible here
-    }
-    else {
+    if (-not $token) {
         Write-Host "Failed to get token."
         exit 1
     }
@@ -144,22 +127,20 @@ $usersUri = "$userManagementUri/usermanagement/users/$organizationId/$userindex"
 Notify -name "Requesting Users and Groups" -itemName "Requesting Users and Groups" -itemResult "None" -message "Requesting Users and Groups from Adobe Management API" -category "Info" -state "None"
 
 while ($lastPageUsers -eq $false) {
-    try {
-        $response= Invoke-RestMethod -Uri $usersUri -Method Get -Headers $groupHeaders
-        $usersResponse += $response.users       
-    }
-    catch {
-        if ($_.Exception.Response.StatusCode -eq 429) {
-            $retryAfter = $_.Exception.Response.Headers.GetValues("Retry-After")[0]
-            $retryAfterMinutes = [math]::Ceiling($retryAfter / 60)
-            Notify -name "Request Failed" -itemName "Request Failed" -itemResult "Error" -message "Too many requests. Retry after $retryAfter seconds ($retryAfterMinutes minutes)." -category "Error" -state "Faulty"
-            
+    $resp = Invoke-LoginWebRequest -Uri $usersUri -Method GET -Headers $groupHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if (-not $resp.IsSuccess) {
+        if ($resp.StatusCode -eq 429) {
+            $retryAfter = if ($resp.Headers -and $resp.Headers["Retry-After"]) { $resp.Headers["Retry-After"] } else { "unknown" }
+            Notify -name "Request Failed" -itemName "Request Failed" -itemResult "Error" -message "Too many requests. Retry after $retryAfter seconds." -category "Error" -state "Faulty"
             exit
         }
-        else {
-            throw $_
-        }
+        Write-Host "Fehler beim Abrufen der Users: HTTP $($resp.StatusCode) $($resp.StatusDescription)"
+        exit 1
     }
+
+    $response = $resp.Body | ConvertFrom-Json
+    $usersResponse += $response.users
     Notify -name "Got Users" -itemName "Got Users" -itemResult "None" -message "Got users from page $userindex" -category "Info" -state "None"
     $userindex++
     $usersUri = "$userManagementUri/usermanagement/users/$organizationId/$userindex"
@@ -169,21 +150,20 @@ while ($lastPageUsers -eq $false) {
 }
 
 while ($lastPageGroups -eq $false) {
-    try {
-        $response2= Invoke-RestMethod -Uri $orgGroupsUri -Method Get -Headers $groupHeaders
-        $groupsResponse += $response2.groups
-        }
-    catch {
-        if ($_.Exception.Response.StatusCode -eq 429) {
-            $retryAfter = $_.Exception.Response.Headers.GetValues("Retry-After")[0]
-            $retryAfterMinutes = [math]::Ceiling($retryAfter / 60)
-            Write-Host "Too many requests. Retry after $retryAfter seconds ($retryAfterMinutes minutes)."
+    $resp2 = Invoke-LoginWebRequest -Uri $orgGroupsUri -Method GET -Headers $groupHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if (-not $resp2.IsSuccess) {
+        if ($resp2.StatusCode -eq 429) {
+            $retryAfter = if ($resp2.Headers -and $resp2.Headers["Retry-After"]) { $resp2.Headers["Retry-After"] } else { "unknown" }
+            Write-Host "Too many requests. Retry after $retryAfter seconds."
             exit
         }
-        else {
-            throw $_
-        }
+        Write-Host "Fehler beim Abrufen der Groups: HTTP $($resp2.StatusCode) $($resp2.StatusDescription)"
+        exit 1
     }
+
+    $response2 = $resp2.Body | ConvertFrom-Json
+    $groupsResponse += $response2.groups
     Notify -name "Got Groups" -itemName "Got Groups" -itemResult "None" -message "Got groups from page $groupindex" -category "Info" -state "None"
     $groupindex++
     $orgGroupsUri = "$userManagementUri/usermanagement/groups/$organizationId/$groupindex"
@@ -275,5 +255,5 @@ foreach ($user in $users) {
 }
 
 Notify -name "Writing Data" -itemName "AdobeApi" -message $filePath -category "Info" -state "Running"
-WriteInv -filePath $filePath -version $scope.Version
+WriteInv -filePath $filePath -version $ctx.Version
 Notify -name "Writing Data Done" -itemName "AdobeApi" -message "-" -category "Info" -state "Finished" -itemResult "Ok"

--- a/AppTec360-MobileDevices.ps1
+++ b/AppTec360-MobileDevices.ps1
@@ -34,14 +34,15 @@ param (
     [string]$parameter = ""
 )
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
+. (Join-Path -Path $PSScriptRoot -ChildPath "include\WebRequest.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'AppTec360'
 #end of default header ----------------------------------------------------------------------
 
 # Variablen für Authentifizierung
-$apiUrl = $scope.Parameters["apiUrl"]
-$apiKey = $scope.Parameters["apiKey"]
-$privateKeyPath = $scope.Parameters["privateKeyPath"]
+$apiUrl = $ctx.UserParameters["apiUrl"]
+$apiKey = $ctx.UserParameters["apiKey"]
+$privateKeyPath = $ctx.UserParameters["privateKeyPath"]
 
 # Zeitstempel in Unix-Zeit
 $timeStamp = [Math]::Floor((Get-Date -UFormat %s))
@@ -75,7 +76,14 @@ $headersGetIDs = @{
     "signature" = $signatureGetIDs
 }
 
-$responseGetIDs = Invoke-RestMethod -Uri $apiUrl -Method Post -Headers $headersGetIDs -Body $requestDataGetIDs
+$respGetIDs = Invoke-LoginWebRequest -Method POST -Uri $apiUrl -Headers $headersGetIDs -Body $requestDataGetIDs -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+if (-not $respGetIDs.IsSuccess) {
+    Write-Host "Fehler beim Abrufen der IDs: HTTP $($respGetIDs.StatusCode) $($respGetIDs.StatusDescription)"
+    return
+}
+
+$responseGetIDs = $respGetIDs.Body | ConvertFrom-Json
 
 if ($responseGetIDs.errors -and $responseGetIDs.errors.Count -gt 0) {
     Write-Host "Fehler beim Abrufen der IDs: $($responseGetIDs.errors | Out-String)"
@@ -101,7 +109,14 @@ $headersGetAssets = @{
     "signature" = $signatureGetAssets
 }
 
-$responseGetAssets = Invoke-RestMethod -Uri $apiUrl -Method Post -Headers $headersGetAssets -Body $requestDataGetAssets
+$respGetAssets = Invoke-LoginWebRequest -Method POST -Uri $apiUrl -Headers $headersGetAssets -Body $requestDataGetAssets -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+if (-not $respGetAssets.IsSuccess) {
+    Write-Host "Fehler beim Abrufen der Gerätedaten: HTTP $($respGetAssets.StatusCode) $($respGetAssets.StatusDescription)"
+    return
+}
+
+$responseGetAssets = $respGetAssets.Body | ConvertFrom-Json
 
 if ($responseGetAssets.errors -and $responseGetAssets.errors.Count -gt 0) {
     Write-Host "Fehler beim Abrufen der Gerätedaten: $($responseGetAssets.errors | Out-String)"
@@ -224,5 +239,5 @@ foreach ($item in $responseGetAssets.result) {
         Notify -name $name -itemName "Inventarisierung" -message $name -category "Info" -state "Finished"
     }
 }
-$filePath = "$($scope.DataDir)\apptec$($scope.TimeStamp).inv"
-WriteInv -filePath "$filePath" -version $scope.Version
+$filePath = "$($ctx.DataDir)\apptec$($ctx.TimeStamp).inv"
+WriteInv -filePath "$filePath" -version $ctx.Version

--- a/AzureAd-Devices-Compliant.ps1
+++ b/AzureAd-Devices-Compliant.ps1
@@ -36,23 +36,23 @@ param (
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'AzureAD'
 #end of default header ----------------------------------------------------------------------
 
-$filePath = "$($scope.DataDir)\azure-$($scope.TimeStamp).inv"
+$filePath = "$($ctx.DataDir)\azure-$($ctx.TimeStamp).inv"
 
 # Required Modules
 #Install-Module -Name Microsoft.Graph
 #Install-Module -Name Microsoft.Graph.Authentication
 #Install-Module -Name Microsoft.Graph.Users
 
-$namefilter = $scope.Parameters["namefilter"];
-$enabledAccountsOnly = $scope.Parameters["enabledAccountsOnly"] -eq "true";
-$validCompliantStatesOnly = $scope.Parameters["validCompliantStatesOnly"] -eq "true";
+$namefilter = $ctx.UserParameters["namefilter"];
+$enabledAccountsOnly = $ctx.UserParameters["enabledAccountsOnly"] -eq "true";
+$validCompliantStatesOnly = $ctx.UserParameters["validCompliantStatesOnly"] -eq "true";
 
-$TenantId = $scope.Parameters["tenantId"]
-$ClientId = $scope.Parameters["clientId"]
-$ClientSecret = $scope.Parameters["clientSecret"]
+$TenantId = $ctx.UserParameters["tenantId"]
+$ClientId = $ctx.UserParameters["clientId"]
+$ClientSecret = $ctx.UserParameters["clientSecret"]
 
 $securePassword = ConvertTo-SecureString -String $ClientSecret -AsPlainText -Force
 $pscredential = New-Object System.Management.Automation.PSCredential ($ClientId, $securePassword)
@@ -93,7 +93,7 @@ try {
         # Reactive archived assets
         AddPropertyValue -name "Archived" -value ""
         AddPropertyValue -name "Custom.Compliant" -value $compliantValue
-        AddPropertyValue -name "LastInventory.Timestamp" -value $scope.TimeStamp2
+        AddPropertyValue -name "LastInventory.Timestamp" -value $ctx.TimeStamp2
         AddPropertyValue -name "OperatingSystem.Name" -value $($device.OperatingSystem)
         AddPropertyValue -name "OperatingSystem.Version" -value $($device.OperatingSystemVersion)
                         
@@ -120,7 +120,7 @@ try {
     }
     
     Notify -name "Writing Data" -itemName "MSGRAPH" -message $filePath -category "Info" -state "None"        
-    WriteInv -filePath $filePath -version $scope.Version
+    WriteInv -filePath $filePath -version $ctx.Version
     Notify -name "Writing Data Done" -itemName "MSGRAPH" -message $filePath -category "Info" -state "Finished"
 }
 catch {

--- a/Device-Software-WMI.ps1
+++ b/Device-Software-WMI.ps1
@@ -26,10 +26,10 @@ param (
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'WMI'
 #end of default header ----------------------------------------------------------------------
 
-$filePath = "$($scope.DataDir)\wmisoft$($scope.TimeStamp).inv"
+$filePath = "$($ctx.DataDir)\wmisoft$($ctx.TimeStamp).inv"
 
 function Get-SoftwareInfo {
     param (
@@ -83,5 +83,5 @@ foreach ($computerName in $computers) {
 }
 
 Notify -name "WMI" -itemName "Writing Data $($elements.Count) Elements" -message $filePath -category "Info" -state "None"
-WriteInv -filePath $filePath -version $scope.Version
+WriteInv -filePath $filePath -version $ctx.Version
 Notify -name "WMI-" -itemName "Writing Data Done" -message $filePath -category "Info" -state "Finished"

--- a/IntuneDevices.ps1
+++ b/IntuneDevices.ps1
@@ -39,15 +39,15 @@ param (
 )
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'Intune'
 #end of default header ----------------------------------------------------------------------
 
 
 # Variables for authentication
-$tenantId = $scope.Parameters["tenantId"]  # Azure AD Tenant ID
-$clientId = $scope.Parameters["clientId"]  # Azure AD App Registration Client ID
-$clientSecret = $scope.Parameters["clientSecret"]  # Azure AD App Registration Client Secret
-$scanOnlyMobileDevices = $scope.Parameters["scanOnlyMobileDevices"] # Boolean to determine if only mobile devices should be scanned (optional)
+$tenantId = $ctx.UserParameters["tenantId"]  # Azure AD Tenant ID
+$clientId = $ctx.UserParameters["clientId"]  # Azure AD App Registration Client ID
+$clientSecret = $ctx.UserParameters["clientSecret"]  # Azure AD App Registration Client Secret
+$scanOnlyMobileDevices = $ctx.UserParameters["scanOnlyMobileDevices"] # Boolean to determine if only mobile devices should be scanned (optional)
 
 # Convert the ClientSecret to a SecureString
 $clientSecretSecurePass = ConvertTo-SecureString -String $clientSecret -AsPlainText -Force
@@ -155,11 +155,11 @@ foreach($device in $devices) {
 }
 
 # Define file name and file path
-$fileName = "$($scope.TimeStamp)@Intune.inv"
-$filePath = "$($scope.DataDir)\$fileName"
+$fileName = "$($ctx.TimeStamp)@Intune.inv"
+$filePath = "$($ctx.DataDir)\$fileName"
 
 # Generate inventory file and save it in the data directory
-WriteInv -filePath "$filePath" -version $scope.Version
+WriteInv -filePath "$filePath" -version $ctx.Version
 
 # Notify LOGINventory Job Monitor
 Notify -name "Writing Data" -itemName "Inventory" -itemResult "Ok" -message "Intune" -category "Info" -state "Finished"

--- a/SophosMDM-MobileDevices.ps1
+++ b/SophosMDM-MobileDevices.ps1
@@ -35,8 +35,9 @@ param (
     [string]$parameter = ""
 )
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
+. (Join-Path -Path $PSScriptRoot -ChildPath "include\WebRequest.ps1")
 
-$ctx = New-CommonContext -Parameters $parameter -StartLabel 'STARTER'
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'SophosMDM'
 # End of default header ----------------------------------------------------------------------
 
 
@@ -63,13 +64,21 @@ $tokenBody = @{
 }
 Write-CommonDebug -Context $ctx -Message "Fetching Access Token..."
 
-$tokenResponse = Invoke-RestMethod -Method Post -Uri $tokenUri `
-    -Body $tokenBody `
-    -ContentType "application/x-www-form-urlencoded"
+$tokenBodyParts = $tokenBody.GetEnumerator() | ForEach-Object { "$($_.Key)=$([uri]::EscapeDataString($_.Value))" }
+$tokenBodyEncoded = $tokenBodyParts -join "&"
+$tokenHeaders = @{ "Content-Type" = "application/x-www-form-urlencoded" }
 
+$tokenResp = Invoke-LoginWebRequest -Method POST -Uri $tokenUri -Body $tokenBodyEncoded -Headers $tokenHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+if (-not $tokenResp.IsSuccess) {
+    Notify -name "Error" -itemName "Error retrieving Access Token" -message "Check if client ID and Secret are correct and if https://id.sophos.com/api/v2/oauth2/token can be reached" -category "Error" -state "Faulty" -ItemResult "Error"
+    throw "No access_token received. HTTP $($tokenResp.StatusCode) $($tokenResp.StatusDescription)"
+}
+
+$tokenResponse = $tokenResp.Body | ConvertFrom-Json
 $accessToken = $tokenResponse.access_token
 
-if (-not $accessToken) {    
+if (-not $accessToken) {
     Notify -name "Error" -itemName "Error retrieving Access Token" -message "Check if client ID and Secret are correct and if https://id.sophos.com/api/v2/oauth2/token can be reached" -category "Error" -state "Faulty" -ItemResult "Error"
     throw "No access_token received in response. Response: $($tokenResponse | ConvertTo-Json -Depth 5)"
 }
@@ -85,7 +94,13 @@ $baseHeaders = @{
 $whoamiUri = "https://api.central.sophos.com/whoami/v1"
 Write-CommonDebug -Context $ctx -Message "Calling whoami endpoint..."
 
-$whoami = Invoke-RestMethod -Method Get -Uri $whoamiUri -Headers $baseHeaders
+$whoamiResp = Invoke-LoginWebRequest -Method GET -Uri $whoamiUri -Headers $baseHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+if (-not $whoamiResp.IsSuccess) {
+    throw "Whoami request failed: HTTP $($whoamiResp.StatusCode) $($whoamiResp.StatusDescription)"
+}
+
+$whoami = $whoamiResp.Body | ConvertFrom-Json
 
 $tenantId   = $whoami.id
 $dataRegion = $whoami.apiHosts.dataRegion.TrimEnd('/')
@@ -116,7 +131,14 @@ do {
 
     Write-CommonDebug -Context $ctx -Message "Fetching page $page $listUri"
 
-    $resp = Invoke-RestMethod -Method Get -Uri $listUri -Headers $mobileHeaders
+    $listResp = Invoke-LoginWebRequest -Method GET -Uri $listUri -Headers $mobileHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if (-not $listResp.IsSuccess) {
+        Write-CommonDebug -Context $ctx -Message "Page ${page}: HTTP error $($listResp.StatusCode) -> breaking list loop."
+        break
+    }
+
+    $resp = $listResp.Body | ConvertFrom-Json
 
     if (-not $resp.items) {
         Write-CommonDebug -Context $ctx -Message "Page ${page}: no items -> breaking list loop."
@@ -160,45 +182,39 @@ foreach ($id in $allDeviceIds) {
     Notify -name "Getting Data" -itemName "Getting Data" -itemResult "None" "[$index/$total] - Getting device details" -category "Info" -state "Detecting"
     Write-CommonDebug -Context $ctx -Message ("[{0}/{1}] GET {2}" -f $index, $total, $id)
 
-    try {
-        $detail = Invoke-RestMethod -Method Get -Uri $detailUri -Headers $mobileHeaders
+    $detailResp = Invoke-LoginWebRequest -Method GET -Uri $detailUri -Headers $mobileHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
 
-        # Retrieve serial number separately as it is not included in standard details
-        $serialNumber = $null
-        # Slight delay to avoid rate limiting
-        Start-Sleep -Milliseconds 100
-        try {
-            $serialUri = "$dataRegion/mobile/v1/devices/${id}/properties?devicePropertyKey=device.serial-number"
-            $serialResponse = Invoke-RestMethod -Method Get -Uri $serialUri -Headers $mobileHeaders
-
-            if ($serialResponse.items) {
-                $serialItem = $serialResponse.items | Select-Object -First 1
-                $serialNumber = $serialItem.value
-            }
-        }
-        catch {
-            Write-CommonDebug -Context $ctx -Message "   -> Serial number for device ${id} could not be retrieved: $($_.Exception.Message)"
-
-            if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
-                Write-CommonDebug -Context $ctx -Message "      Error details: $($_.ErrorDetails.Message)"
-            }
-        }
-
-        if ($serialNumber) {
-            $detail | Add-Member -NotePropertyName serialNumber -NotePropertyValue $serialNumber -Force
-        }
-
-        $fullDevices += $detail
-    }
-    catch {
-        Write-CommonDebug -Context $ctx -Message "   -> Error retrieving device ${id}: $($_.Exception.Message)"
-
-        # Try to read error message from response body if available
-        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
-            Write-CommonDebug -Context $ctx -Message "      Error details: $($_.ErrorDetails.Message)"
-        }
+    if (-not $detailResp.IsSuccess) {
+        Write-CommonDebug -Context $ctx -Message "   -> Error retrieving device ${id}: HTTP $($detailResp.StatusCode) $($detailResp.StatusDescription)"
         continue
     }
+
+    $detail = $detailResp.Body | ConvertFrom-Json
+
+    # Retrieve serial number separately as it is not included in standard details
+    $serialNumber = $null
+    # Slight delay to avoid rate limiting
+    Start-Sleep -Milliseconds 100
+
+    $serialUri = "$dataRegion/mobile/v1/devices/${id}/properties?devicePropertyKey=device.serial-number"
+    $serialResp = Invoke-LoginWebRequest -Method GET -Uri $serialUri -Headers $mobileHeaders -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if ($serialResp.IsSuccess) {
+        $serialResponse = $serialResp.Body | ConvertFrom-Json
+        if ($serialResponse.items) {
+            $serialItem = $serialResponse.items | Select-Object -First 1
+            $serialNumber = $serialItem.value
+        }
+    }
+    else {
+        Write-CommonDebug -Context $ctx -Message "   -> Serial number for device ${id} could not be retrieved: HTTP $($serialResp.StatusCode) $($serialResp.StatusDescription)"
+    }
+
+    if ($serialNumber) {
+        $detail | Add-Member -NotePropertyName serialNumber -NotePropertyValue $serialNumber -Force
+    }
+
+    $fullDevices += $detail
 
     # Slight delay to avoid rate limiting
     Start-Sleep -Milliseconds 100

--- a/baramundi-MobileDevices.ps1
+++ b/baramundi-MobileDevices.ps1
@@ -33,13 +33,14 @@ param (
     [string]$parameter = ""
 )
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
+. (Join-Path -Path $PSScriptRoot -ChildPath "include\WebRequest.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'Baramundi'
 #end of default header ----------------------------------------------------------------------
 
 # Variables for authentication
-$apiUrl = $scope.Parameters["apiUrl"]
-$apiKey = $scope.Parameters["apiKey"]
+$apiUrl = $ctx.UserParameters["apiUrl"]
+$apiKey = $ctx.UserParameters["apiKey"]
 
 # Build the headers hashtable
 $headers = @{
@@ -65,7 +66,14 @@ function Get-AndProcess-EndpointData {
         $currentUrl = $baseUrl + "?page=" + $pageNumber
 
         # Make the GET request
-        $response = Invoke-RestMethod -Uri $currentUrl -Method Get -Headers $headers
+        $resp = Invoke-LoginWebRequest -Uri $currentUrl -Method GET -Headers $headers -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+        if (-not $resp.IsSuccess) {
+            Write-Host "Fehler beim Abrufen von ${endpointType}: HTTP $($resp.StatusCode) $($resp.StatusDescription)"
+            return
+        }
+
+        $response = $resp.Body | ConvertFrom-Json
 
         # Add the current page's data to the $allItems array
         $allItems += $response.data
@@ -137,5 +145,5 @@ function Get-AndProcess-EndpointData {
 Get-AndProcess-EndpointData -endpointType "IosEndpoints"
 Get-AndProcess-EndpointData -endpointType "AndroidEndpoints"
 
-$filePath = "$($scope.DataDir)\baramundi$($scope.TimeStamp).inv"
-WriteInv -filePath "$filePath" -version $scope.Version
+$filePath = "$($ctx.DataDir)\baramundi$($ctx.TimeStamp).inv"
+WriteInv -filePath "$filePath" -version $ctx.Version

--- a/csv-user-import.ps1
+++ b/csv-user-import.ps1
@@ -52,13 +52,13 @@ param (
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'CSVImport'
 #end of default header ----------------------------------------------------------------------
 
-$filePath = "$($scope.DataDir)\userimport-$($scope.TimeStamp).inv"
+$filePath = "$($ctx.DataDir)\userimport-$($ctx.TimeStamp).inv"
 
 # Path to the CSV file
-$csvPath = $scope.Parameters["pathCSV"]
+$csvPath = $ctx.UserParameters["pathCSV"]
 
 # Import the CSV file and store it in a variable
 $users = Import-Csv -Path $csvPath -Delimiter ';'
@@ -109,7 +109,7 @@ try {
     }
     if ($countAddedUsers -gt 0){
         Notify -name "Writing Data" -itemName "CSV" -message $filePath -category "Info" -state "None" -itemResult "Ok"        
-        WriteInv -filePath $filePath -version $scope.Version
+        WriteInv -filePath $filePath -version $ctx.Version
         Notify -name "Writing Data Done" -itemName "CSV" -message $filePath -category "Info" -state "Finished" -itemResult "Ok"
     }
 }      

--- a/jetbrains.ps1
+++ b/jetbrains.ps1
@@ -29,12 +29,13 @@ param (
 )
 
 . (Join-Path -Path $PSScriptRoot -ChildPath "include\common.ps1")
+. (Join-Path -Path $PSScriptRoot -ChildPath "include\WebRequest.ps1")
 
-$scope = Init -encodedParams $parameter
+$ctx = New-CommonContext -Parameters $parameter -StartLabel 'JetBrains'
 #end of default header ----------------------------------------------------------------------
 
 
-$filePath = "$($scope.DataDir)\jetbrains-$($scope.TimeStamp).inv"
+$filePath = "$($ctx.DataDir)\jetbrains-$($ctx.TimeStamp).inv"
 
 function ToValidJson {
     param (
@@ -55,10 +56,10 @@ function ToValidJson {
     return $json
 }
 
-Notify -name "Datadir" -itemName "Data Directory" -message $($scope.DataDir) -category "Info" -state "None" -info "hallo"
+Notify -name "Datadir" -itemName "Data Directory" -message $($ctx.DataDir) -category "Info" -state "None" -info "hallo"
 
-$apiKey = $scope.Parameters["apiKey"]
-$customerCode = $scope.Parameters["customerCode"]
+$apiKey = $ctx.UserParameters["apiKey"]
+$customerCode = $ctx.UserParameters["customerCode"]
 $uri = "https://account.jetbrains.com/api/v1/customer/licenses"
 
 $headers = @{
@@ -68,8 +69,15 @@ $headers = @{
 }
 
 try {
-        
-    $response = Invoke-RestMethod -Uri $uri -Method Get -Headers $headers
+
+    $resp = Invoke-LoginWebRequest -Uri $uri -Method GET -Headers $headers -ProxyConfig $ctx.ProxyConfig -DebugFile $ctx.DebugFile
+
+    if (-not $resp.IsSuccess) {
+        Write-Host "Fehler beim Abrufen der JetBrains-Lizenzen: HTTP $($resp.StatusCode) $($resp.StatusDescription)"
+        exit 1
+    }
+
+    $response = $resp.Body | ConvertFrom-Json
 
     foreach ($item in $response) {                
         $product = ToValidJson -dataString $item.product | ConvertFrom-Json
@@ -105,7 +113,7 @@ try {
     }
 
     Notify -name "Writing Data" -itemName "JetApi" -message $filePath -category "Info" -state "Running"
-    WriteInv -filePath $filePath -version $scope.Version
+    WriteInv -filePath $filePath -version $ctx.Version
     Notify -name "Writing Data Done" -itemName "JetApi" -message $filePath -category "Info" -state "Finished" -itemResult "Ok"
 }
 catch {


### PR DESCRIPTION
## Summary
- All scripts migrated from `Init`/`$scope` to `New-CommonContext`/`$ctx` pattern
- Scripts with HTTP calls now use `Invoke-LoginWebRequest` instead of `Invoke-RestMethod`
- Automatic proxy support, debug logging, retry logic and charset detection for all web requests

## Migrated scripts

| Script | Migration |
|--------|-----------|
| AppTec360-MobileDevices.ps1 | Context + WebRequest |
| Adobe-Cloud-Subscriptions.ps1 | Context + WebRequest |
| baramundi-MobileDevices.ps1 | Context + WebRequest |
| jetbrains.ps1 | Context + WebRequest |
| SophosMDM-MobileDevices.ps1 | WebRequest (already had ctx) |
| AzureAd-Devices-Compliant.ps1 | Context only (MS Graph SDK) |
| IntuneDevices.ps1 | Context only (MS Graph SDK) |
| csv-user-import.ps1 | Context only (no web requests) |
| Device-Software-WMI.ps1 | Context only (WMI) |

## Test plan
- [ ] Verify Adobe Cloud Subscriptions scan runs with token auth + pagination
- [ ] Verify baramundi mobile device scan with API key auth + pagination
- [x] Verify JetBrains license scan
- [ ] Verify Sophos MDM scan (token, whoami, device list, detail, serial)
- [ ] Verify AzureAD / Intune scans with MS Graph SDK still work
- [ ] Verify CSV user import
- [ ] Verify proxy support works when configured
- [ ] Verify debug log files are written when enabled