### PR TITLE
Add Linux publisher fallback for CyberInsight

### DIFF
--- a/CyberInsight/Post-CyberInsightLiData.ps1
+++ b/CyberInsight/Post-CyberInsightLiData.ps1
@@ -212,7 +212,7 @@ function Start-CyberInsightPost {
             # Compose request body
             $jsonBodyObject = [PSCustomObject]@{
                 company_name = $ctx.CompanyName
-                devices      = $deviceObjects
+                devices      = @($deviceObjects)
             }
 
             # Robust: ensure we produce a JSON ARRAY payload (PS5 compatible)

--- a/CyberInsight/Post-CyberInsightLiData.ps1
+++ b/CyberInsight/Post-CyberInsightLiData.ps1
@@ -111,9 +111,10 @@ function Start-CyberInsightPost {
                 
                 foreach ($sw in $deviceGroup.Group) {
                     # For Linux devices with no Publisher, fall back to Device.OperatingSystem.Name
+                    # (only when the column is present in the export query)
                     $publisher = if ($sw.Publisher) {
                         $sw.Publisher
-                    } elseif ($sw.Platform -eq 'Linux' -and $sw.'Device.OperatingSystem.Name') {
+                    } elseif ($sw.Platform -eq 'Linux' -and $sw.PSObject.Properties['Device.OperatingSystem.Name'] -and $sw.'Device.OperatingSystem.Name') {
                         $sw.'Device.OperatingSystem.Name'
                     } else {
                         ""

--- a/CyberInsight/Post-CyberInsightLiData.ps1
+++ b/CyberInsight/Post-CyberInsightLiData.ps1
@@ -20,6 +20,9 @@
     Notes:
       - Devices with more than one matching row in the LI export are included, exactly as in the original logic.
       - The working directory is restored after accessing the LI: drive (Push/Pop-Location).
+      - The LI export query (ExportQuery / "Vulnerability Export") must include the column
+        Device.OperatingSystem.Name. For Linux devices where SWPackage.Publisher is empty,
+        Device.OperatingSystem.Name is used as the publisher fallback.
 
     Requirements:
       - include\common.ps1           (context building, helpers, Notify, etc.)
@@ -107,8 +110,17 @@ function Start-CyberInsightPost {
                 $buckets = @{} # Key = rule index, Value = List<PSObject>
                 
                 foreach ($sw in $deviceGroup.Group) {
+                    # For Linux devices with no Publisher, fall back to Device.OperatingSystem.Name
+                    $publisher = if ($sw.Publisher) {
+                        $sw.Publisher
+                    } elseif ($sw.Platform -eq 'Linux' -and $sw.'Device.OperatingSystem.Name') {
+                        $sw.'Device.OperatingSystem.Name'
+                    } else {
+                        ""
+                    }
+
                     $item = [PSCustomObject]@{
-                        software_publisher = if ($sw.Publisher) { $sw.Publisher } else { "" }
+                        software_publisher = $publisher
                         software_name      = $sw.Name
                         software_version   = if ($sw.Version)   { $sw.Version   } else { "" }
                         software_metadata  = $sw.Platform


### PR DESCRIPTION
## Summary
- Adds fallback logic to derive the publisher from `Device.OperatingSystem.Name` for Linux devices where no explicit publisher is set
- Guards the fallback against missing OS.Name column
- Forces devices to array to prevent single-device serialization issues

## Changed files
- `CyberInsight/Post-CyberInsightLiData.ps1`

## Test plan
- [ ] Verify CyberInsight POST with multiple Linux devices
- [ ] Verify CyberInsight POST with a single Linux device (array serialization fix)
- [ ] Verify devices with existing publisher are not affected by fallback
- [ ] Verify devices without OS.Name column don't cause errors